### PR TITLE
Export data to KML

### DIFF
--- a/evacsim/__init__.py
+++ b/evacsim/__init__.py
@@ -1,9 +1,10 @@
-
-
 from evacsim import EvacSim
 
 ev = EvacSim()
 ev.parse_args(ev.init_args())
 ev.load_models()
+ev.export_kml()
 
-#python __init__.py --nodes nodes.csv --edges edges.csv --disaster hurricanes.csv --main main.csv
+# Example usage from the root directory:
+# python evacsim/__init__.py --nodes nodes.csv --edges edges.csv --disaster disaster.csv --dir troy_model --export export.kml
+# These arguments can be omitted to use the default values.

--- a/evacsim/evacsim.py
+++ b/evacsim/evacsim.py
@@ -11,7 +11,7 @@ import exporter
 class EvacSim:
 
     def __init__(self):
-        self.args = {'nodes': 'nodes.csv', 'edges': 'edges.csv', 'disaster': 'disaster.csv', 'dir': 'models/troy_model/'}
+        self.args = {'nodes': 'nodes.csv', 'edges': 'edges.csv', 'disaster': 'disaster.csv', 'dir': 'models/troy_model/', 'export': 'export.kml'}
         self.nodes = {}
         self.edges = []
         self.disaster = None
@@ -24,6 +24,7 @@ class EvacSim:
         parser.add_argument('--edges', '-e', help='Specify edges model file name')
         parser.add_argument('--disaster', '-d', help='Specify disaster model file name')
         parser.add_argument('--dir', help='Specify directory to read models from')
+        parser.add_argument('--export', help='Specify a filename for the exported KML data')
         return parser
     
     def parse_args(self, parser):
@@ -37,6 +38,8 @@ class EvacSim:
             self.args['disaster'] = args.disaster
         if args.dir:
             self.args['dir'] = args.dir
+        if args.export:
+            self.args['export'] = args.export
     
     def load_models(self):
         """Loads the models from the file names in the arguments"""
@@ -70,5 +73,6 @@ class EvacSim:
     
     def export_kml(self):
         """Exports the models to a KML file"""
-        exp = exporter.Exporter(self.nodes, self.edges, self.disaster, self.routes)
+        print('Exporting models to ' + self.args['export'] + '...')
+        exp = exporter.Exporter(self.nodes, self.edges, self.disaster, self.routes, self.args['export'])
         exp.export_kml()

--- a/evacsim/evacsim.py
+++ b/evacsim/evacsim.py
@@ -6,6 +6,7 @@ import node
 import edge
 import disaster
 import polygon
+import exporter
 
 class EvacSim:
 
@@ -14,6 +15,7 @@ class EvacSim:
         self.nodes = {}
         self.edges = []
         self.disaster = None
+        self.routes = []
     
     def init_args(self):
         """Creates an argument parser, adds arguments, and returns the parser"""
@@ -65,4 +67,8 @@ class EvacSim:
                     self.disaster = disaster.Disaster(row['Name'])
                     disaster_created = True
                 self.disaster.add_data(disaster.Disaster.Data(row['Time'], polygon.Polygon(row['Latitude1'], row['Longitude1'], row['Latitude2'], row['Longitude2'], row['Latitude3'], row['Longitude3'], row['Latitude4'], row['Longitude4'])))
-
+    
+    def export_kml(self):
+        """Exports the models to a KML file"""
+        exp = exporter.Exporter(self.nodes, self.edges, self.disaster, self.routes)
+        exp.export_kml()

--- a/evacsim/exporter.py
+++ b/evacsim/exporter.py
@@ -2,11 +2,12 @@ import simplekml
 
 class Exporter:
 
-    def __init__(self, nodes, edges, disaster, routes):
+    def __init__(self, nodes, edges, disaster, routes, filename):
         self.nodes = nodes
         self.edges = edges
         self.disaster = disaster
         self.routes = routes
+        self.filename = filename
     
     def export_kml(self):
         """Exports the nodes (cities), edges (infrastructure), disaster data, and evacuation routes to a KML file"""
@@ -27,4 +28,4 @@ class Exporter:
             kml.newpolygon(name=self.disaster.name, description=str(datum.time), outerboundaryis=[(datum.effect.lng1, datum.effect.lat1), (datum.effect.lng2, datum.effect.lat2), (datum.effect.lng3, datum.effect.lat3), (datum.effect.lng4, datum.effect.lat4)])
         
         # Export KML file
-        kml.save('export.kml')
+        kml.save(self.filename)

--- a/evacsim/exporter.py
+++ b/evacsim/exporter.py
@@ -17,15 +17,15 @@ class Exporter:
 
         # Add nodes to KML
         for node in self.nodes.values():
-            kml.newpoint(name=node.name, coords=[(node.lng, node.lat)], description='Test node')
+            kml.newpoint(name=node.name, description=f'Population: {node.population}\nCapacity: {node.capacity}', coords=[(node.lng, node.lat)])
         
         # Add edges to KML
         for edge in self.edges:
-            kml.newlinestring(name=f'Edge between {edge.source.name}, {edge.dest.name}', coords=[(edge.source.lng, edge.source.lat), (edge.dest.lng, edge.dest.lat)])
+            kml.newlinestring(name=f'Infrastructure between {edge.source.name} and {edge.dest.name}', description=f'Travel Time: {edge.travelTime}\nCapacity: {edge.capacity}', coords=[(edge.source.lng, edge.source.lat), (edge.dest.lng, edge.dest.lat)])
         
         # Add disaster data to KML
         for datum in self.disaster.data:
-            kml.newpolygon(name=self.disaster.name, description=str(datum.time), outerboundaryis=[(datum.effect.lng1, datum.effect.lat1), (datum.effect.lng2, datum.effect.lat2), (datum.effect.lng3, datum.effect.lat3), (datum.effect.lng4, datum.effect.lat4)])
+            kml.newpolygon(name=self.disaster.name, description=f'Time: {str(datum.time)}', outerboundaryis=[(datum.effect.lng1, datum.effect.lat1), (datum.effect.lng2, datum.effect.lat2), (datum.effect.lng3, datum.effect.lat3), (datum.effect.lng4, datum.effect.lat4)])
         
         # Export KML file
         kml.save(self.filename)

--- a/evacsim/exporter.py
+++ b/evacsim/exporter.py
@@ -27,5 +27,15 @@ class Exporter:
         for datum in self.disaster.data:
             kml.newpolygon(name=self.disaster.name, description=f'Time: {str(datum.time)}', outerboundaryis=[(datum.effect.lng1, datum.effect.lat1), (datum.effect.lng2, datum.effect.lat2), (datum.effect.lng3, datum.effect.lat3), (datum.effect.lng4, datum.effect.lat4)])
         
+        # Add evacuation routes to KML
+        for route in self.routes:
+            # Get the coordinates for each node in the path
+            path_coords = [edge.source for edge in route.path]
+            path_coords.append(route.path[-1])
+
+            # Create and style linestring for this route
+            route_line = kml.newlinestring(name=f'Evacuation route from {route.getSource()} to {route.getDest()}', description=f'Total Travel Time: {route.getTotalTravelTime()}', coords=path_coords)
+            route_line.style.linestyle.color = simplekml.Color.red
+
         # Export KML file
         kml.save(self.filename)

--- a/evacsim/exporter.py
+++ b/evacsim/exporter.py
@@ -1,0 +1,30 @@
+import simplekml
+
+class Exporter:
+
+    def __init__(self, nodes, edges, disaster, routes):
+        self.nodes = nodes
+        self.edges = edges
+        self.disaster = disaster
+        self.routes = routes
+    
+    def export_kml(self):
+        """Exports the nodes (cities), edges (infrastructure), disaster data, and evacuation routes to a KML file"""
+
+        # Create a new KML file representation. Keep in mind that all coordinates in this representation must be in longitude/latitude form, rather than latitude/longitude as in other parts of the project.
+        kml = simplekml.Kml()
+
+        # Add nodes to KML
+        for node in self.nodes.values():
+            kml.newpoint(name=node.name, coords=[(node.lng, node.lat)], description='Test node')
+        
+        # Add edges to KML
+        for edge in self.edges:
+            kml.newlinestring(name=f'Edge between {edge.source.name}, {edge.dest.name}', coords=[(edge.source.lng, edge.source.lat), (edge.dest.lng, edge.dest.lat)])
+        
+        # Add disaster data to KML
+        for datum in self.disaster.data:
+            kml.newpolygon(name=self.disaster.name, description=str(datum.time), outerboundaryis=[(datum.effect.lng1, datum.effect.lat1), (datum.effect.lng2, datum.effect.lat2), (datum.effect.lng3, datum.effect.lat3), (datum.effect.lng4, datum.effect.lat4)])
+        
+        # Export KML file
+        kml.save('export.kml')

--- a/evacsim/route.py
+++ b/evacsim/route.py
@@ -1,0 +1,16 @@
+class Route:
+
+    def __init__(self, source, path, dest):
+        self.path = path
+    
+    def getSource(self):
+        return self.path[0].source
+    
+    def getDest(self):
+        return self.path[-1].dest
+
+    def getTotalTravelTime(self):
+        totalTravelTime = 0
+        for edge in source.path:
+            totalTravelTime += edge.travelTime
+        return totalTravelTime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+simplekml


### PR DESCRIPTION
## What is changed/new?
Cities, infrastructure, disaster data, and evacuation routes can now be exported to a KML file and viewed in Google Earth. The data associated with these models, such as the population and max capacity for cities, can be viewed as well.

## How was this implemented?
A `export_kml()` function and an associated argument to specify the export filename has been added to the `EvacSim` class. This function creates a new `Exporter` object that uses the `simplekml` library to add all of the application's models to a KML representation and save it to a file.

## Any related issues?
#7: Export data to KML file
