### PR TITLE
Allow polygons to have any number of sides

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ following `nodes.csv` file modeling populations around Troy, NY:
 Similar models exist for edges and natural disasters:
 - `edges.csv`: Models infrastructure (ie. roads) between populations by source
   node, destination node, transit time, and maximum capacity.
-- `disaster.csv`: Models the natural disaster by its area of effect at
-  different times.
+- `disaster.csv`: Models the natural disaster with polygons, representing its
+  area of effect at different times. Area of effect polygons can have any
+  number of sides, as long as they are ordered clockwise or counter-clockwise.
 
 Examples can be found in the [models](../models/) folder.
 

--- a/evacsim/evacsim.py
+++ b/evacsim/evacsim.py
@@ -77,7 +77,12 @@ class EvacSim:
                 if not disaster_created:
                     self.disaster = disaster.Disaster(row['Name'])
                     disaster_created = True
-                self.disaster.add_data(disaster.Disaster.Data(row['Time'], polygon.Polygon(float(row['Latitude1']), float(row['Longitude1']), float(row['Latitude2']), float(row['Longitude2']), float(row['Latitude3']), float(row['Longitude3']), float(row['Latitude4']), float(row['Longitude4']))))
+                index = 1
+                points = []
+                while f'Latitude{index}' in row and f'Longitude{index}' in row:
+                    points.append((float(row[f'Latitude{index}']), float(row[f'Longitude{index}'])))
+                    index += 1
+                self.disaster.add_data(disaster.Disaster.Data(row['Time'], polygon.Polygon(points)))
 
     def get_affected_nodes(self):
         """Finds all nodes within the natural disaster's area of effect"""

--- a/evacsim/exporter.py
+++ b/evacsim/exporter.py
@@ -28,7 +28,7 @@ class Exporter:
 
         # Add disaster data to KML
         for datum in self.disaster.data:
-            kml.newpolygon(name=self.disaster.name, description=f'Time: {str(datum.time)}', outerboundaryis=[(datum.effect.lng1, datum.effect.lat1), (datum.effect.lng2, datum.effect.lat2), (datum.effect.lng3, datum.effect.lat3), (datum.effect.lng4, datum.effect.lat4)])
+            kml.newpolygon(name=self.disaster.name, description=f'Time: {str(datum.time)}', outerboundaryis=datum.effect.reverseLatLng())
 
         # Add evacuation routes to KML
         for route in self.routes:

--- a/evacsim/polygon.py
+++ b/evacsim/polygon.py
@@ -5,17 +5,15 @@ class Polygon:
     Represents a polygon represented by latitude/longitude points, for use in disaster data to define its area of effect at a given time
     """
 
-    def __init__(self, lat1, lng1, lat2, lng2, lat3, lng3, lat4, lng4):
-        self.lat1 = lat1
-        self.lng1 = lng1
-        self.lat2 = lat2
-        self.lng2 = lng2
-        self.lat3 = lat3
-        self.lng3 = lng3
-        self.lat4 = lat4
-        self.lng4 = lng4
+    def __init__(self, points):
+        """Create a new polygon from points, which should be an array of latitude/longitude tuples"""
+        self.points = points
 
     def contains(self, lat, lng):
         """Returns true if the given latitude/longitude point is within this polygon, false otherwise"""
-        shapely_polygon = shapely.geometry.Polygon([(self.lat1, self.lng1), (self.lat2, self.lng2), (self.lat3, self.lng3), (self.lat4, self.lng4)])
+        shapely_polygon = shapely.geometry.Polygon(self.points)
         return shapely_polygon.contains(shapely.geometry.Point(lat, lng))
+
+    def reverseLatLng(self):
+        """Returns the points in this polygon in longitude/latitude form rather than latitude/longitude form"""
+        return [(point[1], point[0]) for point in self.points]


### PR DESCRIPTION
## What is changed/new?
Polygons used to model a natural disaster can now have any number of sides, as long as the points are ordered either clockwise or counter-clockwise, and the readme has been updated to reflect this.

## How was this implemented?
Removed the `lat1`, `lng1`, `lat2`, `lng2`, `...` fields from the `Polygon` class and replaced it with a `points` list of latitude/longitude tuples. Added a `reverseLatLng()` function to reverse the order of these tuples, as the KML exporter expects longitude/latitude points. Updated the natural disaster data parsing to load as many points as are provided. Updated the readme to reflect these changes.

## Any related issues?
#19: Allow polygons to have more than 4 sides