### PR TITLE
Style evacuation routes

### DIFF
--- a/evacsim/exporter.py
+++ b/evacsim/exporter.py
@@ -11,6 +11,7 @@ class Exporter:
         self.disaster = disaster
         self.routes = routes
         self.filename = filename
+        self.route_colors = [simplekml.Color.blue, simplekml.Color.red, simplekml.Color.green, simplekml.Color.purple, simplekml.Color.orange]
 
     def export_kml(self):
         """Exports the nodes (cities), edges (infrastructure), disaster data, and evacuation routes to a KML file"""
@@ -20,7 +21,11 @@ class Exporter:
 
         # Add nodes to KML
         for node in self.nodes.values():
-            kml.newpoint(name=node.name, description=f'Population: {node.population}\nCapacity: {node.capacity}', coords=[(node.lng, node.lat)])
+            desc = f'Population: {node.population}\nCapacity: {node.capacity}'
+            for route in self.routes:
+                if route.source == node:
+                    desc += f'\n{route}'
+            kml.newpoint(name=node.name, description=desc, coords=[(node.lng, node.lat)])
 
         # Add edges to KML
         for edge in self.edges:
@@ -30,6 +35,24 @@ class Exporter:
         for datum in self.disaster.data:
             kml.newpolygon(name=self.disaster.name, description=f'Time: {str(datum.time)}', outerboundaryis=datum.effect.reverse_lat_lng())
 
+        # Assign colors to each affected city's evacuation routes
+        source_colors = {}
+        color_index = 0
+        for route in self.routes:
+            if route.source.name not in source_colors:
+                source_colors[route.source.name] = self.route_colors[color_index]
+                # Increment color index for next route
+                color_index += 1
+                if color_index >= len(self.route_colors):
+                    color_index = 0
+        
+        # Assign widths to each affected city's evacuation routes
+        source_widths = {}
+        width_index = 0
+        for node_name in source_colors:
+            source_widths[node_name] = (len(source_colors) - width_index) * 8
+            width_index += 1
+
         # Add evacuation routes to KML
         for route in self.routes:
             # Get the coordinates for each node in the path
@@ -37,7 +60,8 @@ class Exporter:
 
             # Create and style linestring for this route
             route_line = kml.newlinestring(name=f'Evacuation route from {route.source.name} to {route.dest.name}', description=f'Total Travel Time: {route.get_total_travel_time()}', coords=path_coords)
-            route_line.style.linestyle.color = simplekml.Color.red
+            route_line.style.linestyle.color = source_colors[route.source.name]
+            route_line.style.linestyle.width = 4
 
         # Export KML file
         kml.save(self.filename)


### PR DESCRIPTION
## What is changed/new?
Each node's evacuation routes in an exported KML file are now styled with a different color and width.

## How was this implemented?
In `exporter.py`, pick a new color from a list of predetermined colors for each node's evacuation routes, and increment the width for each new node.

## Any related issues?
#18: Style exported KML objects for higher contrast
